### PR TITLE
API: Allow a 'setup' function to create some state for performance tests

### DIFF
--- a/src/Reperf.re
+++ b/src/Reperf.re
@@ -22,10 +22,10 @@ module Make = (Config: Args) => {
   type setupFunction('a) = unit => 'a;
   type testFunction('a) = 'a => unit;
 
-  let defaultSetupFunction: setupFunction(unit) = () => ();
+  /* let defaultSetupFunction: setupFunction(unit) = () => (); */
 
   let bench =
-      (~name: string, ~setup:setupFunction('a)=defaultSetupFunction, ~f: testFunction('a), ~options=Config.config.options, ()) => {
+      (~name: string, ~setup:setupFunction('a), ~f: testFunction('a), ~options=Config.config.options, ()) => {
     let newCase = () => {
       let opts = options;
       let iter = () => {
@@ -35,7 +35,6 @@ module Make = (Config: Args) => {
 
         Gc.full_major();
         let beforeState = Gc.quick_stat();
-
         let startTime = _getTime();
         let count = ref(0);
         while (count^ < opts.iterations) {


### PR DESCRIPTION
Often for benchmarks, you want to set up some state (like a node tree) - you don't want that 'setup' to be part of the core benchmark, but you want operations on that state to benchmarked.

This adds a setup function with some state to be called prior to iterating the benchmark function