### PR TITLE
Fix building by adding printbox-text to Dune file

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (library
   (name reperf)
   (flags (-w -40 -w +26))
-  (libraries unix printbox)
+  (libraries unix printbox-text)
   (public_name reperf.lib))


### PR DESCRIPTION
To fix building:
```
       > File "src/Reporter.re", line 32, characters 40-60:
       > 32 |   PrintBox.(frame(grid_text(table))) |> PrintBox_text.output(stdout);
       >                                              ^^^^^^^^^^^^^^^^^^^^
       > Error: Unbound module PrintBox_text
```
I suppose `printbox` doesn't have to be added because `printbox-text` will propagate it automatically.